### PR TITLE
Uses UTF-8 as default encoding

### DIFF
--- a/a2l2xml.py
+++ b/a2l2xml.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-#
+# coding: utf-8
 #BSD 2-Clause License
 #
 #Copyright (c) 2016, Eduard Bröcker
@@ -36,7 +36,7 @@ if len(sys.argv) < 3:
 
 inputFile = open(sys.argv[1],"r")
 outputFile = open(sys.argv[2],"w")
-inputBuf = inputFile.read().replace('\n', '')
+inputBuf = inputFile.read().replace('\n', '').decode('utf-8')
 
 length = len(inputBuf)
 


### PR DESCRIPTION
We hade some issue with a2l files that are using non-ASCII characters - setting the default encoding to UTF-8 and explicitly decoding the input file's content helped us. I'm not sure predefining the coding for all use cases and users makes sense, but anyhow here's the PR.