### PR TITLE
Removes explicit processing of RECORD_LAYOUTs

### DIFF
--- a/a2l2xml.py
+++ b/a2l2xml.py
@@ -81,8 +81,6 @@ conversionTypes = ['IDENTICAL','FORM','LINEAR','RAT_FUNC','TAB_INTP','TAB_NOINTP
 
 xcpOnCanTypes = ['BTL_CYCLES','CAN_ID_BROADCAST','CAN_ID_MASTER','CAN_ID_MASTER_INCREMENTAL','CAN_ID_SLAVE','CAN_ID_GET_DAQ_CLOCK_MULTICAST','BAUDRATE','SAMPLE_POINT','SAMPLE_RATE','SJW','SYNC_EDGE''DAQ_LIST_CAN_ID','EVENT_CAN_ID_LIST', 'MAX_BUS_LOAD','MAX_DLC_REQUIRED','MEASUREMENT_SPLIT_ALLOWED','CAN_FD','MAX_DLC','CAN_FD_DATA_TRANSFER_BAUDRATE','SECONDARY_SAMPLE_POINT','TRANSCEIVER_DELAY_COMPENSATION']
 xcpOnFlexRayTypes = ['FLX_BUF','MAX_FLX_LEN_BUF','LPDU_ID','FLX_SLOT_ID','OFFSET','CYCLE_REPETITION','CHANNEL','XCP_PACKET','INITIAL_CMD_BUFFER','INITIAL_RES_ERR_BUFFER','POOL_BUFFER']
-xcpOnFlxRayXcpPacketTypes = ['CMD','RES_ERR','EV_SERV','DAQ','STIM','MULTICAST']
-xcpOnFlxRayHeaderNaxTypes = ['HEADER_NAX', 'HEADER_NAX_FILL','HEADER_NAX_CTR','HEADER_NAX_FILL3','HEADER_NAX_CTR_FILL2','HEADER_NAX_LEN','HEADER_NAX_CTR_LEN','HEADER_NAX_FILL2_LEN','HEADER_NAX_CTR_FILL_LEN']
 
 def getNextToken(pos):
     while pos < length:
@@ -204,12 +202,6 @@ def processOutline(current, pos, outline):
         current.append(child)
     elif outline in xcpOnFlexRayTypes:
         child = etree.Element("xcpOnFlexRay", type=outline)
-        current.append(child)
-    elif outline in xcpOnFlxRayXcpPacketTypes:
-        child = etree.Element("xcpOnFlxRayXcpPacketType", type=outline)
-        current.append(child)
-    elif outline in xcpOnFlxRayHeaderNaxTypes:
-        child = etree.Element("xcpOnFlxRayHeaderNaxType", type=outline)
         current.append(child)
     else:
         child = etree.Element("item", type=outline)

--- a/a2l2xml.py
+++ b/a2l2xml.py
@@ -80,7 +80,7 @@ layoutTypes = ['ROW_DIR', 'COLUMN_DIR']
 conversionTypes = ['IDENTICAL','FORM','LINEAR','RAT_FUNC','TAB_INTP','TAB_NOINTP','TAB_VERB']
 
 xcpOnCanTypes = ['BTL_CYCLES','CAN_ID_BROADCAST','CAN_ID_MASTER','CAN_ID_MASTER_INCREMENTAL','CAN_ID_SLAVE','CAN_ID_GET_DAQ_CLOCK_MULTICAST','BAUDRATE','SAMPLE_POINT','SAMPLE_RATE','SJW','SYNC_EDGE''DAQ_LIST_CAN_ID','EVENT_CAN_ID_LIST', 'MAX_BUS_LOAD','MAX_DLC_REQUIRED','MEASUREMENT_SPLIT_ALLOWED','CAN_FD','MAX_DLC','CAN_FD_DATA_TRANSFER_BAUDRATE','SECONDARY_SAMPLE_POINT','TRANSCEIVER_DELAY_COMPENSATION']
-xcpOnFlexRayTypes = ['FLX_BUF','MAX_FLX_LEN_BUF','LPDU_ID','FLX_SLOT_ID','OFFSET','CYCLE_REPETITION','CHANNEL','XCP_PACKET','INITIAL_CMD_BUFFER','INITIAL_RES_ERR_BUFFER','POOL_BUFFER']
+xcpOnFlxTypes = ['FLX_BUF','MAX_FLX_LEN_BUF','LPDU_ID','FLX_SLOT_ID','OFFSET','CYCLE_REPETITION','CHANNEL','XCP_PACKET','INITIAL_CMD_BUFFER','INITIAL_RES_ERR_BUFFER','POOL_BUFFER']
 
 def getNextToken(pos):
     while pos < length:
@@ -200,8 +200,8 @@ def processOutline(current, pos, outline):
     elif outline in xcpOnCanTypes:
         child = etree.Element("xcpOnCan", type=outline)
         current.append(child)
-    elif outline in xcpOnFlexRayTypes:
-        child = etree.Element("xcpOnFlexRay", type=outline)
+    elif outline in xcpOnFlxTypes:
+        child = etree.Element("xcpOnFlx", type=outline)
         current.append(child)
     else:
         child = etree.Element("item", type=outline)

--- a/a2l2xml.py
+++ b/a2l2xml.py
@@ -244,32 +244,6 @@ def processBlock(current, pos, blkname):
             return startPos
         current.attrib["comment"] = comment
         return pos
-    elif blkname == "RECORD_LAYOUT":
-        [pos, tt, tok] = getNextToken(pos)
-        if tt != "OUTLINE":
-            return startPos
-        current.attrib["name"] = tok
-        [pos, tt, tok] = getNextToken(pos)
-        if tt != "OUTLINE":
-            return startPos
-        current.attrib["type"] = tok
-        [pos, tt, tok] = getNextToken(pos)
-        if tt != "OUTLINE":
-            return startPos
-        current.attrib["position"] = tok
-        [pos, tt, tok] = getNextToken(pos)
-        if tt != "OUTLINE":
-            return startPos
-        current.attrib["datatype"] = tok
-        [pos, tt, tok] = getNextToken(pos)
-        if tt != "OUTLINE":
-            return startPos
-        current.attrib["index"] = tok
-        [pos, tt, tok] = getNextToken(pos)
-        if tt != "OUTLINE":
-            return startPos
-        current.attrib["addrType"] = tok
-        return pos
     return startPos
 
 

--- a/a2l2xml.py
+++ b/a2l2xml.py
@@ -79,9 +79,6 @@ indexOrders = ['INDEX_INCR', 'INDEX_DECR']
 layoutTypes = ['ROW_DIR', 'COLUMN_DIR']
 conversionTypes = ['IDENTICAL','FORM','LINEAR','RAT_FUNC','TAB_INTP','TAB_NOINTP','TAB_VERB']
 
-xcpOnCanTypes = ['BTL_CYCLES','CAN_ID_BROADCAST','CAN_ID_MASTER','CAN_ID_MASTER_INCREMENTAL','CAN_ID_SLAVE','CAN_ID_GET_DAQ_CLOCK_MULTICAST','BAUDRATE','SAMPLE_POINT','SAMPLE_RATE','SJW','SYNC_EDGE''DAQ_LIST_CAN_ID','EVENT_CAN_ID_LIST', 'MAX_BUS_LOAD','MAX_DLC_REQUIRED','MEASUREMENT_SPLIT_ALLOWED','CAN_FD','MAX_DLC','CAN_FD_DATA_TRANSFER_BAUDRATE','SECONDARY_SAMPLE_POINT','TRANSCEIVER_DELAY_COMPENSATION']
-xcpOnFlxTypes = ['FLX_BUF','MAX_FLX_LEN_BUF','LPDU_ID','FLX_SLOT_ID','OFFSET','CYCLE_REPETITION','CHANNEL','XCP_PACKET','INITIAL_CMD_BUFFER','INITIAL_RES_ERR_BUFFER','POOL_BUFFER']
-
 def getNextToken(pos):
     while pos < length:
         if inputBuf[pos:pos+2] == "/*":
@@ -200,12 +197,6 @@ def processOutline(current, pos, outline):
         current.append(child)
     elif outline in conversionTypes:
         child = etree.Element("conversionType", type=outline)
-        current.append(child)
-    elif outline in xcpOnCanTypes:
-        child = etree.Element("xcpOnCan", type=outline)
-        current.append(child)
-    elif outline in xcpOnFlxTypes:
-        child = etree.Element("xcpOnFlx", type=outline)
         current.append(child)
     else:
         child = etree.Element("item", type=outline)


### PR DESCRIPTION
Until now only simple RECORD_LAYOUTs could be processed (e.g. containing only FNC_VALUES or AXIS_PTS_X). But since RECORD_LAYOUTs could become quite complex (e.g. ALIGNMENTS, FIX_NO_AXIS_PTS, etc.) this is not enough.

Example:

        /begin RECORD_LAYOUT SWORD_COL_DIRECT
        ALIGNMENT_FLOAT64_IEEE 4
        FNC_VALUES 1 SWORD COLUMN_DIR DIRECT
        /end RECORD_LAYOUT
        
Result:

        <RECORD_LAYOUT>
        <item type="SWORD_COL_DIRECT"/>
        <keyword type="ALIGNMENT_FLOAT64_IEEE"/>
        <item type="4"/>
        <keyword type="FNC_VALUES"/>
        <item type="1"/>
        <datatype type="SWORD"/>
        <layoutType type="COLUMN_DIR"/>
        <addrType type="DIRECT"/>
        </RECORD_LAYOUT>